### PR TITLE
Add isReady to user type and entity

### DIFF
--- a/src/app/typeDefs/user.ts
+++ b/src/app/typeDefs/user.ts
@@ -5,6 +5,7 @@ export default gql`
 		_id: ID!
 		name: String!
 		email: String!
+		isReady: Boolean!
 		room: Room
 	}
 
@@ -20,6 +21,7 @@ export default gql`
 	input UpdateUserInput {
 		name: String
 		email: String
+		isReady: Boolean
 	}
 
 	input RegisterUserInput {

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -9,6 +9,9 @@ class User extends Typegoose {
 
 	@prop({ required: true, trim: true })
 	password: string
+
+	@prop({ default: false })
+	isReady: boolean
 }
 
 export default new User().getModelForClass(User, {

--- a/src/ts-types/generated.ts
+++ b/src/ts-types/generated.ts
@@ -12,6 +12,8 @@ export interface UpdateUserInput {
 	name?: Maybe<string>
 
 	email?: Maybe<string>
+
+	isReady?: Maybe<boolean>
 }
 
 export interface LoginCredentials {
@@ -68,6 +70,8 @@ export interface User {
 	name: string
 
 	email: string
+
+	isReady: boolean
 
 	room?: Maybe<Room>
 }
@@ -249,6 +253,8 @@ export interface UserResolvers<TContext = {}, TypeParent = User> {
 
 	email?: UserEmailResolver<string, TypeParent, TContext>
 
+	isReady?: UserIsReadyResolver<boolean, TypeParent, TContext>
+
 	room?: UserRoomResolver<Maybe<Room>, TypeParent, TContext>
 }
 
@@ -264,6 +270,11 @@ export type UserNameResolver<
 > = Resolver<R, Parent, TContext>
 export type UserEmailResolver<
 	R = string,
+	Parent = User,
+	TContext = {}
+> = Resolver<R, Parent, TContext>
+export type UserIsReadyResolver<
+	R = boolean,
 	Parent = User,
 	TContext = {}
 > = Resolver<R, Parent, TContext>

--- a/src/ts-types/user.ts
+++ b/src/ts-types/user.ts
@@ -7,6 +7,7 @@ export interface UserInput {
 export interface UpdateUserInput {
 	name?: string
 	email?: string
+	isReady?: string
 }
 
 export interface UserPayload {


### PR DESCRIPTION
### Description/Notes

Adding isReady as a type to trigger when a user is ready to start the session

### Submitter Checklist

#### All PRs

- [x] I have reviewed my own code line-by-line (no stray `console.log` statements or `TODO` comments)

<!-- Remove this section if it is not applicable: -->

### Reviewer Checklist

#### Dev

- [ ] I understand all the code in this PR and have verified that it is correct to the best of my ability
  - [ ] I have left comments or reached out to the author for clarification on any parts I don't understand
